### PR TITLE
Update to 9.0.200 SDK

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4.3.0
       with:
-        dotnet-version: 9.0.102
+        dotnet-version: 9.0.200
     - name: Restore dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
9.0.102 is unlisted now, so just not going to use it.